### PR TITLE
Add ColorMod

### DIFF
--- a/src/entities/CTaskWorm.cpp
+++ b/src/entities/CTaskWorm.cpp
@@ -16,6 +16,18 @@ int __fastcall CTaskWorm::hookWormHandleMessage(CTaskWorm * This, int EDX, CTask
 				This->selected_weapon_entry_ptr36C = weaponTable + 464 * This->selected_weapon_unknown170;
 			}
 			break;
+		case Constants::TaskMessage_RenderScene:
+			{
+				// This enables ColorMod (originally from RubberWorm)
+				DWORD gameglobal = W2App::getAddrGameGlobal();
+				DWORD *colors = (DWORD*)(gameglobal + 0x72D8 + 0x30); // 0x7248 in 3.7.2
+				DWORD oldColor = colors[7];
+				colors[7] = colors[This->color_dword10C + 1];
+				int retVal = origWormHandleMessage(This, EDX, sender, mtype, size, data);
+				colors[7] = oldColor;
+				return retVal;
+			}
+			break;
 		case Constants::TaskMessage_WormState: {
 			WormState *state = (WormState *) data;
 			state->apply(This);

--- a/src/entities/CTaskWorm.h
+++ b/src/entities/CTaskWorm.h
@@ -14,8 +14,8 @@ public:
 	int teamnumber_dwordFC; // 0xFC
 	int wormnumber_dword100; // 0x100
 	int active_dword104; // 0x104
-	int unknown108; // 0x108
-	int unknown10C; // 0x10C
+	int suspended_dword108; // 0x108
+	int color_dword10C; // 0x10C
 	int unknown110; // 0x110
 	int unknown114; // 0x114
 	int unknown118; // 0x118


### PR DESCRIPTION
This adds ColorMod from RubberWorm 0.0.1.11b+. This is mostly the original code adjusted for wkRealTime's environment, and perhaps more ways to achieve this can be found.

ColorMod changes the default "grey" color of worm labels and rope segment outlines to mimic the player's color. This is helpful in RTW mode with multiple worms on the scene.
![image](https://user-images.githubusercontent.com/5569139/151672989-426500d3-79ad-4c60-9dff-74d03dad0ba0.png)
